### PR TITLE
Adds fields to cargo.toml for crates.io and extra documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,11 @@
 name = "screen_printer"
 version = "0.1.0"
 edition = "2021"
+license = "MIT"
+authors = ["Link <CirnoStrongest9909@hotmail.com>"]
+readme = "README.md"
+repository = "https://github.com/LinkTheDot/screen_printer"
+description = "A crate for creating and/or printing grids"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/dynamic_printer.rs
+++ b/src/dynamic_printer.rs
@@ -41,7 +41,7 @@ pub trait DynamicPrinter {
   /// in grids.
   ///
   /// # Example
-  /// ```
+  /// ```rust,no_run
   /// use screen_printer::printer::*;
   ///
   /// let width = 3;
@@ -51,28 +51,26 @@ pub trait DynamicPrinter {
   /// let grid1 = "abc\n123\nxyz".to_string();
   /// let grid2 = "abc\n123\nasd".to_string();
   ///
-  /// // printer.dynamic_print(grid1).unwrap();
   /// // The first print will remember where to print any future grids.
-  /// //
+  /// printer.dynamic_print(grid1).unwrap();
   /// // Should look like
   /// // abc
   /// // 123
   /// // xyz
   ///
-  /// // printer.dynamic_print(grid2).unwrap();
-  /// // The second print will compare the new grid and print only the differences
-  /// // from the previous.
-  /// //
+  /// // The second print will compare the new grid, and
+  /// // print only the differences from the previously printed grid.
+  /// printer.dynamic_print(grid2).unwrap();
   /// // Should look like
   /// // abc
   /// // 123
-  /// // asd
+  /// // asd < only part that got printed
   /// ```
   ///
   /// The way the printer remembers where to print a grid is based on where the cursor was
   /// upon first print.
   /// The cursor's location marks the bottom right of the grid.
-  /// If the x or y of origin are to go out of bounds, said axis be set to 0.
+  /// If the x or y of origin are to go out of bounds, said axis will be set to 0.
   ///
   /// An error is returned when the cursor can't be read or the passed in grid does not match the expected size.
   fn dynamic_print(&mut self, grid: String) -> Result<(), PrintingError>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,57 @@
+//! Screen Printer is a rust crate that will allow you to build and print arrays of
+//! data into a grid format.
+//!
+//! The purpose of this crate is to make it easier to print a grid that's stored in
+//! an array.
+//!
+//! ## Examples
+//!
+//! #### Creating and Printing a Grid
+//!
+//! ```rust
+//! use screen_printer::printer::*;
+//!
+//! const WIDTH: usize = 5;
+//! const HEIGHT: usize = 4;
+//!
+//! fn main() {
+//!   let character_list = vec![
+//!     "a", "b", "c", "d", "e", //
+//!     "f", "g", "h", "i", "j", //
+//!     "k", "l", "m", "n", "o", //
+//!     "p", "q", "r", "s", "t",
+//!   ];
+//!
+//!   let grid =
+//!     Printer::create_grid_from_full_character_list(&character_list, WIDTH, HEIGHT).unwrap();
+//!
+//!   print!("{}", "\n".repeat(HEIGHT * 2)); // This gives the grid space for the first print
+//!   Printer::print_over_previous_grid(grid, HEIGHT);
+//! }
+//! ```
+//!
+//! #### Using the dynamic print method
+//! ```rust,no_run
+//! use screen_printer::printer::*;
+//!
+//! const WIDTH: usize = 3;
+//! const HEIGHT: usize = 3;
+//!
+//! fn main() {
+//!   let mut printer = Printer::new(WIDTH, HEIGHT);
+//!
+//!   let grid_1_rows = vec!["abc", "123", "xyz",];
+//!   let grid_2_rows = vec!["abc", "789", "xyz",];
+//!
+//!   let grid_1 = Printer::create_grid_from_multiple_rows(&grid_1_rows).unwrap();
+//!   let grid_2 = Printer::create_grid_from_multiple_rows(&grid_1_rows).unwrap();
+//!
+//!   printer.dynamic_print(grid_1).unwrap();
+//!   printer.dynamic_print(grid_2).unwrap();
+//! }
+//! ```
+
+/// Methods for efficient grid printing
 pub mod dynamic_printer;
+/// Creation and basic printing for grids
 pub mod printer;


### PR DESCRIPTION
In order to publish this project, this commit adds the required fields to the cargo.toml for crates.io.

In addition, this commit adds extra documentation for the front page of docs.rs about usage of the crate.