### PR TITLE
Adds clone to the PrintingError

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -2,7 +2,7 @@
 ///
 /// Each error will contain 'ErrorData' which holds the
 /// expected and outcome results in the event of the error.
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub enum PrintingError {
   /// When creating a grid, the defined size of the grid was larger than the given amount of characters.
   TooManyCharacters(LengthErrorData),
@@ -41,7 +41,7 @@ pub enum PrintingError {
 
 /// When creating a grid from [`crate::printer::Printer::create_grid_from_full_character_list`](crate::printer::Printer::create_grid_from_full_character_list),
 /// the sizes given and the actual amount of characters didn't match.
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub struct LengthErrorData {
   pub expected_character_count: usize,
   pub actual_character_count: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,7 @@
 #![doc = include_str!("../README.md")]
 
-/// Methods for efficient grid printing
 pub mod dynamic_printer;
-/// Creation and basic printing for grids
-pub mod printer;
-
-pub mod prelude;
-
 pub mod errors;
-
+pub mod prelude;
+pub mod printer;
 pub mod printing_position;


### PR DESCRIPTION
In order to reduce any restrictions for those working with errors from this crate, this commit adds Clone to the PrintingError.