### PR TITLE
Fixes bugs when clearing and changing the size of the grid to be printed

### DIFF
--- a/examples/change_grid_dimensions.rs
+++ b/examples/change_grid_dimensions.rs
@@ -1,0 +1,41 @@
+use screen_printer::printer::*;
+#[allow(unused)]
+use std::{thread, time::Duration};
+
+fn main() {
+  println!("{}", termion::clear::All);
+  let mut printer = Printer::new_with_printing_position(PrintingPosition::new(
+    XPrintingPosition::Middle,
+    YPrintingPosition::Middle,
+  ));
+
+  let printing_list = vec![
+    "x".to_string(),
+    "xx".to_string(),
+    "xxx".to_string(),
+    "xxxx".to_string(),
+    "xxxx\nxxxx".to_string(),
+    "xxxxx\nxxxxx".to_string(),
+    "xxxxxx\nxxxxxx".to_string(),
+    "xxxxxx\nxxxxxx\nxxxxxx".to_string(),
+    "xxxxxxx\nxxxxxxx\nxxxxxxx".to_string(),
+    "xxxxxxxx\nxxxxxxxx\nxxxxxxxx".to_string(),
+    "xxxxxxxx\nxxxxxxxx\nxxxxxxxx\nxxxxxxxx".to_string(),
+    "xxxxxxxxx\nxxxxxxxxx\nxxxxxxxxx\nxxxxxxxxx".to_string(),
+    "xxxxxxxxxx\nxxxxxxxxxx\nxxxxxxxxxx\nxxxxxxxxxx".to_string(),
+    "xxxxxxxxxx\nxxxxxxxxxx\nxxxxxxxxxx\nxxxxxxxxxx\nxxxxxxxxxx".to_string(),
+  ];
+
+  for grid in printing_list.clone() {
+    printer.dynamic_print(grid).unwrap();
+
+    thread::sleep(Duration::from_millis(400));
+  }
+
+  for grid in printing_list.into_iter().rev() {
+    printer.dynamic_print(grid).unwrap();
+
+    thread::sleep(Duration::from_millis(400));
+  }
+  println!("{}", termion::clear::All);
+}

--- a/examples/dynamic_printer.rs
+++ b/examples/dynamic_printer.rs
@@ -1,8 +1,8 @@
 use rand::prelude::*;
 use screen_printer::printer::*;
 
-const WIDTH: usize = 200;
-const HEIGHT: usize = 50;
+// const WIDTH: usize = 200;
+// const HEIGHT: usize = 50;
 
 /// Creates a random list of numbers, prints them, then clears the grid.
 fn main() {
@@ -16,20 +16,31 @@ fn main() {
   ));
 
   let mut rng = rand::thread_rng();
-  let mut list_of_numbers: Vec<u8> = [0; WIDTH * HEIGHT].into(); //Vec::with_capacity(WIDTH * HEIGHT);
+  // let mut first_list_of_numbers: Vec<u8> = [0; WIDTH * HEIGHT].into();
+  // let mut second_list_of_numbers: Vec<u8> = [0; WIDTH * HEIGHT].into();
 
-  for _ in 0..10000 {
-    // Update the grid data
-    update_random_number_array(&mut rng, &mut list_of_numbers);
+  for iteration in 1..=6 {
+    let (width, height, mut list_of_numbers): (usize, usize, Vec<u8>) = if iteration % 2 == 0 {
+      // Print a large grid of numbers.
+      (200, 50, vec![0; 200 * 50])
+    } else {
+      // Print a smaller grid of numbers.
+      (100, 25, vec![0; 100 * 25])
+    };
 
-    // Create a grid with the data
-    let grid =
-      Printer::create_grid_from_full_character_list(&list_of_numbers, WIDTH, HEIGHT).unwrap();
+    for _ in 0..5000 {
+      // Update the grid data
+      update_random_number_array(&mut rng, &mut list_of_numbers);
 
-    // Print the grid
-    printer
-      .dynamic_print(grid)
-      .unwrap_or_else(|error| panic!("An error has occurred: '{error}'"));
+      // Create a grid with the data
+      let grid =
+        Printer::create_grid_from_full_character_list(&list_of_numbers, width, height).unwrap();
+
+      // Print the grid
+      printer
+        .dynamic_print(grid)
+        .unwrap_or_else(|error| panic!("An error has occurred: '{error}'"));
+    }
   }
 
   print!("{}", termion::clear::All);

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -337,6 +337,31 @@ impl Printer {
       ..Default::default()
     }
   }
+
+  pub(crate) fn update_origin(&mut self, new_origin: (usize, usize)) {
+    if let Ok(current_origin) = self.get_origin_position() {
+      if current_origin.0 != new_origin.0 || current_origin.1 != new_origin.1 {
+        self.printing_position_changed_since_last_print = true;
+      }
+      // } else {
+      //   self.printing_position_changed_since_last_print = true;
+    }
+
+    self.origin_position = Some(new_origin);
+  }
+
+  pub(crate) fn update_dimensions(&mut self, new_dimensions: (usize, usize)) {
+    if let Ok(current_dimensions) = self.get_grid_dimensions() {
+      if current_dimensions.0 != new_dimensions.0 || current_dimensions.1 != new_dimensions.1 {
+        self.printing_position_changed_since_last_print = true;
+      }
+      // } else {
+      //   self.printing_position_changed_since_last_print = true;
+    }
+
+    self.grid_width = Some(new_dimensions.0);
+    self.grid_height = Some(new_dimensions.1);
+  }
 }
 
 /// Creates a grid of the given width out of the given 1D array of characters.


### PR DESCRIPTION
In order to fix some bugs, this commit moves any instance where the position of the grid to be printed may change, to it's their methods. That would mean anytime the internal dimensions or origin for the grid. If either of those would change, the
`printing_position_changed_since_last_print` flag is set to true.

In addition, this commit fixes a bug where the `clear_grid` method swapped the width and height of the grid when creating the grid of whitespace to be printed over it.
Along with that, this commit fixes another bug with the `replace_currently_printed_grid` method. Where the origin was not being updated if it already existed.