### PR TITLE
Adds a methods to make non-rectangular grids rectangular and other.

### DIFF
--- a/src/dynamic_printer.rs
+++ b/src/dynamic_printer.rs
@@ -73,7 +73,7 @@ pub trait DynamicPrinter {
 impl DynamicPrinter for Printer {
   fn dynamic_print(&mut self, new_grid: String) -> Result<(), PrintingError> {
     let terminal_dimensions = Printer::get_terminal_dimensions()?;
-    let new_grid_dimensions = Self::valid_rectangle_check(&new_grid)?;
+    let new_grid_dimensions = Self::get_rectangular_dimensions(&new_grid)?;
 
     if new_grid_dimensions.0 > terminal_dimensions.0
       || new_grid_dimensions.1 > terminal_dimensions.1
@@ -281,7 +281,7 @@ impl DynamicPrinterMethods for Printer {
     let (new_grid_width, new_grid_height) = if let Some(new_grid_dimensions) = new_grid_dimensions {
       new_grid_dimensions
     } else {
-      Self::valid_rectangle_check(new_grid)?
+      Self::get_rectangular_dimensions(new_grid)?
     };
 
     // Can return an error if the PrintingPosition was changed before a first print.
@@ -318,7 +318,7 @@ fn print_grid_freestanding(
   grid: &str,
   printing_position: (usize, usize),
 ) -> Result<(), PrintingError> {
-  Printer::valid_rectangle_check(grid)?;
+  Printer::get_rectangular_dimensions(grid)?;
   let mut grid_with_cursor_movements = String::new();
   let cursor_movement = format!("\x1B[1B\x1B[{}G", printing_position.0);
 

--- a/src/dynamic_printer/tests.rs
+++ b/src/dynamic_printer/tests.rs
@@ -548,7 +548,7 @@ static GRID_SIZES: (usize, usize) = (5, 3);
 
 fn get_preassigned_printer() -> Printer {
   let terminal_dimensions = Printer::get_terminal_dimensions().unwrap();
-  let (grid_width, grid_height) = Printer::valid_rectangle_check(BASE_GRID).unwrap();
+  let (grid_width, grid_height) = Printer::get_rectangular_dimensions(BASE_GRID).unwrap();
 
   let mut printer = Printer::new_with_printing_position(
     PrintingPosition::with_y_printing_position(YPrintingPosition::Top),


### PR DESCRIPTION
In order to make the creations of grids for this crate easier, this commit adds a method that will add whitespace to every row of a string so that they match the largest row.

In addition, this commit makes the method for getting a grid's dimensions public, and adds an additional method for checking if a grid is a valid rectangle.