### PR TITLE
Implements thiserror for PrintingError

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,6 +392,7 @@ dependencies = [
  "log4rs",
  "rand",
  "termion",
+ "thiserror",
 ]
 
 [[package]]
@@ -489,18 +490,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.44"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "611040a08a0439f8248d1990b111c95baa9c704c805fa1f62104b39655fd7f90"
+checksum = "1177e8c6d7ede7afde3585fd2513e611227efd6481bd78d2e82ba1ce16557ed4"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.44"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
+checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ description = "A crate for displaying rectangular blocks of text to a terminal."
 [dependencies]
 termion = "2.0.1"
 log = "0.4"
+thiserror = "1.0.49"
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/src/dynamic_printer/tests.rs
+++ b/src/dynamic_printer/tests.rs
@@ -134,7 +134,7 @@ mod get_printable_difference_logic {
       let different_grid = get_modified_base_grid(vec![1, 8]);
       let origin = printer.get_origin_position().unwrap();
 
-      let expected_different_pixels = vec![
+      let expected_different_pixels = [
         PixelDifference {
           pixels: String::from("l"),
           index: 1,
@@ -207,7 +207,7 @@ mod get_printable_difference_logic {
       let different_grid = get_modified_base_grid(vec![0, 1, 8]);
       let origin = printer.get_origin_position().unwrap();
 
-      let expected_different_pixels = vec![
+      let expected_different_pixels = [
         PixelDifference {
           pixels: String::from("ll"),
           index: 0,
@@ -235,7 +235,7 @@ mod get_printable_difference_logic {
       let different_grid = get_modified_base_grid(vec![1, 7, 8]);
       let origin = printer.get_origin_position().unwrap();
 
-      let expected_different_pixels = vec![
+      let expected_different_pixels = [
         PixelDifference {
           pixels: String::from("l"),
           index: 1,
@@ -263,7 +263,7 @@ mod get_printable_difference_logic {
       let different_grid = get_modified_base_grid(vec![1, 4, 6]);
       let origin = printer.get_origin_position().unwrap();
 
-      let expected_different_pixels = vec![
+      let expected_different_pixels = [
         PixelDifference {
           pixels: String::from("l"),
           index: 1,
@@ -316,7 +316,7 @@ mod get_printable_difference_logic {
       let different_grid = get_modified_base_grid(vec![0, 1, 6, 7]);
       let origin = printer.get_origin_position().unwrap();
 
-      let expected_different_pixels: String = vec![
+      let expected_different_pixels: String = [
         PixelDifference {
           pixels: String::from("ll"),
           index: 0,
@@ -344,7 +344,7 @@ mod get_printable_difference_logic {
       let different_grid = get_modified_base_grid(vec![0, 4, 12, 16]);
       let origin = printer.get_origin_position().unwrap();
 
-      let expected_different_pixels: String = vec![
+      let expected_different_pixels: String = [
         PixelDifference {
           pixels: String::from("l"),
           index: 0,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,38 +1,38 @@
+use thiserror::Error;
+
 /// These are the possible ways the program can fail.
 ///
 /// Each error will contain 'ErrorData' which holds the
 /// expected and outcome results in the event of the error.
-#[derive(Debug, Eq, PartialEq, Clone)]
+#[derive(Error, Debug, Clone)]
 pub enum PrintingError {
-  /// When creating a grid, the defined size of the grid was larger than the given amount of characters.
+  #[error("Failed to create a grid as there were too many characters. Expected {}, got {}", .0.expected_character_count, .0.actual_character_count)]
   TooManyCharacters(LengthErrorData),
-  /// When creating a grid, the defined size of the grid was smaller than the given amount of characters.
+  #[error("Failed to create a grid as there weren't enough characters. Expected {}, got {}", .0.expected_character_count, .0.actual_character_count)]
   TooLittleCharacters(LengthErrorData),
 
-  /// A grid was passed in and wasn't in a 2d shape.
-  ///
-  /// Grids are stored as a 1d string, but treated as a 2d shape.
-  /// Each column is a character, and each row is a new line.
-  NonRectangularGrid,
-
-  /// When attempting to get the dimensions of the terminal, an error occurred.
-  ///
-  /// The error message is contained
+  #[error("Failed to obtain the dimensions of the terminal. Reason: {}", .0)]
   FailedToGetTerminalDimensions(String),
-  /// This error is returned when a grid passed in to [`dynamic_print`](crate::dynamic_printer::DynamicPrinter::dynamic_print) is
-  /// larger than the dimensions of the terminal.
+  #[error("A grid larger than the terminal itself was passed in.")]
   GridLargerThanTerminal,
 
-  /// When attempting to get the dimensions of the grid, there were no stored dimensions for the grid.
+  #[error("A non rectangular grid was passed in.")]
+  NonRectangularGrid,
+  #[error("Failed to obtain the stored dimensions of the grid.")]
   GridDimensionsNotDefined,
-  /// Origin was not defined when attempting to obtain it.
-  OriginNotDefined,
-  /// There's no stored terminal dimensions from the previous print.
+  #[error("Failed to obtain the stored terminal dimensions.")]
   TerminalDimensionsNotDefined,
-
-  /// There was no [`PrintingPosition`](crate::printing_position::PrintingPosition) when attempting to get origin from printing position.err
-  MissingPrintingPosition,
+  #[error("Failed to obtain the stored origin position.")]
+  OriginNotDefined,
 }
+
+impl PartialEq for PrintingError {
+  fn eq(&self, other: &Self) -> bool {
+    std::mem::discriminant(self) == std::mem::discriminant(other)
+  }
+}
+
+impl Eq for PrintingError {}
 
 /// When creating a grid from [`crate::printer::Printer::create_grid_from_full_character_list`](crate::printer::Printer::create_grid_from_full_character_list),
 /// the sizes given and the actual amount of characters didn't match.
@@ -44,7 +44,7 @@ pub struct LengthErrorData {
 
 impl LengthErrorData {
   /// Creates a new LengthErrorData for the expected length and actual length
-  pub fn new(expected_character_count: usize, actual_character_count: usize) -> Self {
+  pub(crate) fn new(expected_character_count: usize, actual_character_count: usize) -> Self {
     Self {
       expected_character_count,
       actual_character_count,

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -5,12 +5,6 @@ use std::cmp::Ordering;
 use std::fmt;
 use std::{io, io::Write};
 
-impl fmt::Display for PrintingError {
-  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-    write!(f, "{self:?}")
-  }
-}
-
 /// # Screen Printer
 ///
 /// Screen Printer is a rust crate that will allow you to build and print arrays of


### PR DESCRIPTION
In order to have proper error compatibility, this commit implements thiserror for PrintingError.

In addition, this commit fixes new clippy warnings in tests.